### PR TITLE
Use flake8 to check docstring line lengths

### DIFF
--- a/examples/elastic2d.py
+++ b/examples/elastic2d.py
@@ -67,7 +67,7 @@ grid = vd.distance_mask(
 predicted = chain.predict(projection(*coordinates))
 residuals = (data.velocity_east - predicted[0], data.velocity_north - predicted[1])
 
-# Make maps of the original velocities, the gridded velocities, and the residuals
+# Make maps of the original velocities, gridded velocities, and the residuals
 fig, axes = plt.subplots(
     1, 2, figsize=(12, 8), subplot_kw=dict(projection=ccrs.Mercator())
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -9,5 +9,6 @@ tag_prefix = ''
 ignore = E203, E266, E501, W503, F401, E741
 max-line-length = 88
 max-complexity = 10
+max-doc-length = 79
 exclude =
     erizo/_version.py


### PR DESCRIPTION
Docstrings need to be 79 characters wide since Jupyter/IPython (and
other IDEs) don't really render the text. So longer lines get wrapped
making docstrings unreadable.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
