### PR TITLE
Add my ORCID and affiliation

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -3,4 +3,4 @@
 The following people have made contributions to the project (in alphabetical
 order by last name) and are considered "The Erizo Developers":
 
-* [Leonardo Uieda](https://github.com/leouieda)
+* [Leonardo Uieda](https://github.com/leouieda) - University of Liverpool, UK (ORCID: 0000-0001-6123-9515)


### PR DESCRIPTION
The authorship guidelines introduced in fatiando/contributing#13 specify
that authors on Zenodo archives will be taken from the AUTHORS.md file
and need to have full names, affiliation, and ORCIDs (optionally)
included in that file.



**Reminders**

- [ ] Run `make format` and `make check` to make sure the code follows the style guide.
- [ ] Add tests for new features or tests that would have caught the bug that you're fixing.
- [ ] Add new public functions/methods/classes to `doc/api/index.rst`.
- [ ] Write detailed docstrings for all functions/methods.
- [ ] If adding new functionality, add an example to the docstring, gallery, and/or tutorials.
